### PR TITLE
Stop scrolling the page

### DIFF
--- a/src/inputSources/mouseWheelInput.js
+++ b/src/inputSources/mouseWheelInput.js
@@ -15,6 +15,8 @@
         if (e.originalEvent.type === 'DOMMouseScroll' && e.originalEvent.axis === 1) {
             return;
         }
+        
+        e.preventDefault();
 
         var element = e.currentTarget;
 


### PR DESCRIPTION
Without `e.preventDefault()` the page would still scroll when using the wheel over the canvas